### PR TITLE
Fix playback control and duration formatting

### DIFF
--- a/lib/contexts/video-player-context.tsx
+++ b/lib/contexts/video-player-context.tsx
@@ -58,12 +58,10 @@ export function VideoPlayerProvider({
   );
 
   const play = async () => {
-    playerRef.current?.getInternalPlayer()?.play();
     updateState({ isPlaying: true });
   };
 
   const pause = () => {
-    playerRef.current?.getInternalPlayer()?.pause();
     updateState({ isPlaying: false });
   };
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -8,7 +8,7 @@ export function cn(...inputs: ClassValue[]) {
 export function formatDuration(seconds: number) {
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
-  const s = Math.round(seconds % 60);
+  const s = Math.floor(seconds % 60);
 
   if (h > 0) {
     return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;


### PR DESCRIPTION
## Summary
- avoid calling internal player methods that may not exist
- fix `formatDuration` rounding to prevent invalid times

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846233efcbc8322bcc052946ae252ac