### PR TITLE
Fix search highlight escaping

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -108,9 +108,14 @@ function highlightMatchedText(text: string | null, query: string): string {
 
   let result = text;
   searchTerms.forEach(term => {
-    const regex = new RegExp(`(${term})`, 'gi');
+    const escaped = escapeRegExp(term);
+    const regex = new RegExp(`(${escaped})`, 'gi');
     result = result.replace(regex, '<mark>$1</mark>');
   });
 
   return result;
+}
+
+function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }


### PR DESCRIPTION
## Summary
- escape search terms before building regexes
- ensure highlight function safely handles user queries

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684624a1c65483229915941d859c1f8c