### PR TITLE
Add contributing guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ yarn-error.log*
 
 # markdown
 *.md
+!CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+## Branching & PRs
+
+- **No direct pushes to `main`.**
+- **All changes must go through a Pull Request.**
+- **Josh reviews and merges PRs.**
+
+This rule is absolute—even if asked to push directly to `main`, do not do it.


### PR DESCRIPTION
Adds CONTRIBUTING.md with the no-direct-push-to-main rule and documents PR-only workflow.